### PR TITLE
feat: MongoDB setup and connection and sample seed data

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+MONGODB_URI=
+# set above to mongodb://localhost:27017/database-name for dev
+#                                           ^^^^
+#                                        task-focused

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,68 @@
+# Backend
+
+This is the backend for the Task-Focused project. It is built with Node.js, Express, TypeScript, and MongoDB (via Mongoose).
+
+## Prerequisites
+- Node.js (v18+ recommended)
+- npm
+- MongoDB (local or remote)
+
+## Setup
+
+1. **Install dependencies:**
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment variables:**
+   - Copy `.env.example` to `.env` and update the values as needed.
+   - Example:
+     ```env
+     MONGODB_URI=mongodb://localhost:27017/task-focused
+     ```
+
+3. **Start MongoDB:**
+   - Make sure your MongoDB server is running locally or update the URI for a remote server.
+
+4. **Seed the database (optional):**
+   - To populate the database with sample users:
+     ```bash
+     npm run seed
+     ```
+
+5. **Run the development server:**
+   ```bash
+   npm run dev
+   ```
+
+## Project Structure
+
+- `src/` — Express app source code
+  - `app.ts` — Main app entry point
+  - `routes/` — API route handlers
+    - `ping.ts` — Health check endpoint
+    - `ping-db.ts` — Database connectivity/sample user endpoint
+- `db/` — Database utilities and models
+  - `models/User.ts` — Mongoose User schema/model
+  - `index.ts` — MongoDB connection logic
+  - `mongoConfig.ts` — MongoDB URI utility
+  - `seed.ts` — Database seeding script
+- `.env` — Environment variables (not committed)
+- `.env.example` — Example environment variables
+- `package.json` — NPM scripts and dependencies
+
+## Useful Scripts
+
+- `npm run dev` — Start the backend in development mode
+- `npm run seed` — Seed the database with sample data
+
+## API Endpoints
+
+- `GET /api/ping` — Health check
+- `GET /api/ping-db` — Returns a sample user from the database
+
+## Notes
+- Make sure to keep your `.env` file private and never commit it to version control.
+- For production, update the `MONGODB_URI` to point to your production database.
+
+

--- a/backend/db/index.ts
+++ b/backend/db/index.ts
@@ -1,0 +1,9 @@
+import mongoose from "mongoose";
+import { getMongoUri } from "./mongoConfig";
+
+const connectDB = async () => {
+  await mongoose.connect(getMongoUri());
+  console.log("MongoDB connected");
+};
+
+export default connectDB;

--- a/backend/db/models/User.ts
+++ b/backend/db/models/User.ts
@@ -1,0 +1,10 @@
+import mongoose from "mongoose";
+
+const userSchema = new mongoose.Schema({
+  clerkId: { type: String, required: true, unique: true }, // Link to Clerk user
+  role: { type: String, enum: ["admin", "member"], required: true },
+  organization: { type: String, required: true },
+});
+
+const User = mongoose.model("User", userSchema);
+export default User;

--- a/backend/db/mongoConfig.ts
+++ b/backend/db/mongoConfig.ts
@@ -1,0 +1,10 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+export function getMongoUri(): string {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error("MONGODB_URI is not defined in environment variables.");
+  }
+  return uri;
+}

--- a/backend/db/seed.ts
+++ b/backend/db/seed.ts
@@ -1,0 +1,21 @@
+import mongoose from "mongoose";
+import { getMongoUri } from "./mongoConfig";
+import User from "./models/User";
+
+
+const seedUsers = async () => {
+  await mongoose.connect(getMongoUri());
+
+  const users = [
+    { clerkId: "clerk1", role: "admin", organization: "OrgA" },
+    { clerkId: "clerk2", role: "member", organization: "OrgB" },
+    { clerkId: "clerk3", role: "member", organization: "OrgA" },
+  ];
+
+  await User.deleteMany({});
+  await User.insertMany(users);
+  console.log("Seeded users!");
+  await mongoose.disconnect();
+};
+
+seedUsers().catch(console.error);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,32 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "mongoose": "^9.2.1"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/accepts": {
@@ -47,6 +72,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/bytes": {
@@ -448,6 +482,15 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/kareem": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.2.0.tgz",
+      "integrity": "sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -465,6 +508,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -501,6 +550,104 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
+      "integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.0.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.2.1.tgz",
+      "integrity": "sha512-fmNLwgct5km7iL1MqvTMncarR1E1TIw2lmc9A4UoDVdS7AQe95K+DnRK0qATkSUdwUC9V/5wlDcqnkQQjbSRkA==",
+      "license": "MIT",
+      "dependencies": {
+        "kareem": "3.2.0",
+        "mongodb": "~7.0",
+        "mpath": "0.9.0",
+        "mquery": "6.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+      "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/ms": {
@@ -581,6 +728,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -767,6 +923,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -783,6 +954,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/type-is": {
@@ -815,6 +998,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,12 +5,14 @@
   "main": "index.js",
   "scripts": {
     "dev": "ts-node src/app.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "seed": "ts-node db/seed.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "mongoose": "^9.2.1"
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from "cors";
 
 import pingRouter from './routes/ping';
+import pingDbRouter from './routes/ping-db';
 
 const app = express();
 const PORT = process.env.PORT || 8000;
@@ -11,6 +12,7 @@ app.use(express.json());
 
 // Routes
 app.use('/api', pingRouter);
+app.use('/api', pingDbRouter);
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);

--- a/backend/src/routes/ping-db.ts
+++ b/backend/src/routes/ping-db.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import connectDB from '../../db';
+import User from '../../db/models/User';
+
+const router = Router();
+
+router.get('/ping-db', async (req, res) => {
+  try {
+    await connectDB();
+    const user = await User.findOne();
+    if (user) {
+      res.json({ message: `Database connected\nSample user found: ${user.clerkId}`, user });
+    } else {
+      res.json({ message: 'No users found' });
+    }
+  } catch (err) {
+    res.status(500).json({ message: 'Error connecting to DB or fetching user', error: err });
+  }
+});
+
+export default router;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,12 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
-    "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"],
+  "include": ["src", "db"],
   "exclude": ["node_modules"]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,16 @@ async function pingBackend() {
   }
 }
 
+async function pingDb() {
+  try {
+    const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/ping-db`);
+    const data = await res.json();
+    alert(data.message);
+  } catch {
+    alert('Ping DB failed');
+  }
+}
+
 function App() {
   return (
     <>
@@ -15,6 +25,9 @@ function App() {
       <div className="card">
         <button onClick={pingBackend}>
           Ping backend
+        </button>
+        <button onClick={pingDb} >
+          Ping database
         </button>
         <p>
           Edit <code>src/App.tsx</code>


### PR DESCRIPTION
Added MongoDB connection & ping test in the frontend. Added a readme in the backend with instructions for setting up mongo. I'll reference the setup section below:

## Setup
From the backend directory:
1. **Install dependencies:**
   ```bash
   npm install
   ```

2. **Configure environment variables:**
   - Copy `.env.example` to `.env` and update the values as needed.
   - Example:
     ```env
     MONGODB_URI=mongodb://localhost:27017/task-focused
     ```

3. **Start MongoDB:**
   - Make sure your MongoDB server is running locally (for deployment we can make a remote server)

4. **Seed the database:**
   - To populate the database with sample users:
     ```bash
     npm run seed
     ```

5. **Run the development server:**
   ```bash
   npm run dev
   ```

---
   
   After doing the setup, run `npm run build` in the frontend, reload the extension, and hit the "ping backend" button. If setup correctly, it will return "Backend connected" with a sample username from the seeding (clerk1).

Any questions feel free to ask.

Closes #3 