### PR TITLE
Fixes and Gemini swap

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,4 +3,5 @@ MONGODB_URI=
 #                                           ^^^^
 #                                        task-focused
 
-ZAI_API_KEY=
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -1,5 +1,4 @@
 import { Router, type Request, type Response } from 'express';
-import OpenAI from 'openai';
 import { requireGoogleAuth } from '../middleware/requireGoogleAuth';
 
 const router = Router();
@@ -14,6 +13,23 @@ type ChatRequestBody = {
   messages?: Message[];
 };
 
+type GeminiRole = 'user' | 'model';
+
+function toGeminiRole(role: Message['role']): GeminiRole {
+  return role === 'assistant' ? 'model' : 'user';
+}
+
+function getGeminiTextFromResponse(payload: unknown): string {
+  const data = payload as {
+    candidates?: Array<{
+      content?: { parts?: Array<{ text?: string }> };
+    }>;
+  };
+
+  const parts = data?.candidates?.[0]?.content?.parts ?? [];
+  return parts.map((p) => p.text ?? '').join('').trim();
+}
+
 // Proxy chat requests from the blocked page to the configured LLM provider.
 router.post('/chat', requireGoogleAuth, async (req: Request, res: Response) => {
   const { system, messages } = req.body as ChatRequestBody;
@@ -24,37 +40,53 @@ router.post('/chat', requireGoogleAuth, async (req: Request, res: Response) => {
     return;
   }
 
-  const apiKey = process.env.ZAI_API_KEY;
+  const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
-    res.status(500).json({ message: 'ZAI_API_KEY is not configured.' });
+    res.status(500).json({ message: 'GEMINI_API_KEY is not configured.' });
     return;
   }
 
   try {
-    // Build a client per request using the current server configuration.
-    const client = new OpenAI({
-      apiKey,
-      baseURL: 'https://api.z.ai/api/paas/v4',
+    const model = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
+      model
+    )}:generateContent`;
+
+    const body = {
+      ...(system
+        ? {
+            systemInstruction: {
+              role: 'system',
+              parts: [{ text: system }],
+            },
+          }
+        : {}),
+      contents: messages.map((m) => ({
+        role: toGeminiRole(m.role),
+        parts: [{ text: m.content }],
+      })),
+    };
+
+    const geminiRes = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
+      body: JSON.stringify(body),
     });
 
-    const result = await client.chat.completions.create({
-      model: 'GLM-4.5',
-      messages: [
-        // Include the optional system prompt first when the UI provides one.
-        ...(system ? [{ role: 'system' as const, content: system }] : []),
+    const geminiPayload = (await geminiRes.json()) as unknown;
+    if (!geminiRes.ok) {
+      const details = JSON.stringify(geminiPayload);
+      res.status(502).json({ message: `Gemini API request failed (${geminiRes.status}).`, details });
+      return;
+    }
 
-        // Forward the existing transcript in the provider's expected shape.
-        ...messages.map((m) => ({
-          role: m.role as 'user' | 'assistant',
-          content: m.content,
-        })),
-      ],
-    });
-
-    const content = result.choices[0]?.message?.content ?? '';
+    const content = getGeminiTextFromResponse(geminiPayload);
     res.json({ content });
   } catch (error) {
-    console.error('Z.AI API error', error);
+    console.error('Gemini API error', error);
     res.status(502).json({ message: 'Failed to get response from AI.' });
   }
 });

--- a/extension/background.js
+++ b/extension/background.js
@@ -14,6 +14,7 @@ const TEMP_ALLOW_MAX_MS = 60 * 60 * 1000; // 60 minutes
 const BLOCKED_PAGE_PATH = 'blocked.html';
 const ORG_BLOCKLIST_SYNC_ALARM = 'ORG_BLOCKLIST_SYNC';
 const ORG_BLOCKLIST_MIN_SYNC_WINDOW_MS = 60 * 1000; // 1 minute
+const TEMP_ALLOW_EXPIRE_ALARM_PREFIX = 'TEMP_ALLOW_EXPIRE:';
 
 // Keep in sync with extension/blocked-page.js (dev default).
 const BACKEND_URL = 'http://localhost:8000';
@@ -199,12 +200,24 @@ function clampDurationMs(ms) {
   return Math.min(TEMP_ALLOW_MAX_MS, Math.max(TEMP_ALLOW_MIN_MS, Math.floor(ms)));
 }
 
+function scheduleTemporaryAllowanceExpiryAlarm(allowedHostname, expiryEpochMs) {
+  try {
+    if (!chrome.alarms?.create) return;
+    const name = `${TEMP_ALLOW_EXPIRE_ALARM_PREFIX}${encodeURIComponent(allowedHostname)}`;
+    chrome.alarms.create(name, { when: expiryEpochMs + 50 });
+  } catch (error) {
+    console.warn('Failed to schedule allowance expiry alarm', { allowedHostname, error });
+  }
+}
+
 function addTemporaryAllowanceWithDuration(hostname, durationMs) {
   const canonicalized = canonicalizeHostname(hostname);
   if (!canonicalized) return;
 
   const clamped = clampDurationMs(durationMs);
-  temporaryAllowances.set(canonicalized, Date.now() + clamped);
+  const expiry = Date.now() + clamped;
+  temporaryAllowances.set(canonicalized, expiry);
+  scheduleTemporaryAllowanceExpiryAlarm(canonicalized, expiry);
   console.log(`Temporarily allowed: ${canonicalized} for ${Math.round(clamped / 60000)} min`);
 }
 
@@ -365,8 +378,19 @@ chrome.runtime.onStartup.addListener(() => {
 // Periodically refresh the org blocklist from the backend.
 chrome.alarms?.create?.(ORG_BLOCKLIST_SYNC_ALARM, { periodInMinutes: 5 });
 chrome.alarms?.onAlarm?.addListener((alarm) => {
-  if (alarm?.name !== ORG_BLOCKLIST_SYNC_ALARM) return;
-  void syncOrgBlocklist('alarms.onAlarm');
+  const name = String(alarm?.name ?? '');
+  if (name === ORG_BLOCKLIST_SYNC_ALARM) {
+    void syncOrgBlocklist('alarms.onAlarm');
+    return;
+  }
+
+  if (name.startsWith(TEMP_ALLOW_EXPIRE_ALARM_PREFIX)) {
+    const encoded = name.slice(TEMP_ALLOW_EXPIRE_ALARM_PREFIX.length);
+    const allowedHostname = decodeURIComponent(encoded);
+    temporaryAllowances.delete(allowedHostname);
+    cachedBlocklistSet = null;
+    void rescanOpenTabs('temporaryAllowanceExpired');
+  }
 });
 
 // Clear the cached blocklist and rescan when local storage changes.

--- a/extension/background.js
+++ b/extension/background.js
@@ -168,16 +168,25 @@ function isTemporarilyAllowed(hostname) {
   const canonicalized = canonicalizeHostname(hostname);
   if (!canonicalized) return false;
 
-  const expiry = temporaryAllowances.get(canonicalized);
-  if (typeof expiry !== 'number') return false;
+  const now = Date.now();
 
-  // Drop expired entries the first time they are checked again.
-  if (Date.now() > expiry) {
-    temporaryAllowances.delete(canonicalized);
-    return false;
+  // Allow applies to the exact hostname OR any subdomain of an allowed hostname.
+  // This is important for flows like login/2FA that hop across subdomains.
+  for (const [allowedHostname, expiry] of temporaryAllowances.entries()) {
+    if (typeof expiry !== 'number') continue;
+
+    // Drop expired entries the first time they are checked again.
+    if (now > expiry) {
+      temporaryAllowances.delete(allowedHostname);
+      continue;
+    }
+
+    if (hostnameMatchesBlockedHostname(canonicalized, allowedHostname)) {
+      return true;
+    }
   }
 
-  return true;
+  return false;
 }
 
 // Grant short-term access after the blocked-page AI approves a visit.

--- a/extension/blocked-page.js
+++ b/extension/blocked-page.js
@@ -36,6 +36,134 @@ const LLM_COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
 const LLM_REQUEST_COUNT_KEY = 'llmRequestCount';
 const LLM_COOLDOWN_UNTIL_KEY = 'llmCooldownUntil';
 
+// Persist the blocked-page chat for a short window so refreshes don't erase context.
+const LLM_CHAT_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const LLM_CHAT_STATES_KEY = 'llmChatStates';
+const LLM_SESSION_UPDATED_AT_KEY = 'llmSessionUpdatedAt';
+const LLM_EXPIRY_POLL_MS = 15 * 1000; // 15s
+
+function canonicalizeSiteKey(hostname) {
+  return String(hostname ?? '').trim().toLowerCase();
+}
+
+async function clearLlmSessionState({ clearAllChats } = { clearAllChats: false }) {
+  const updates = {
+    [LLM_REQUEST_COUNT_KEY]: 0,
+    [LLM_COOLDOWN_UNTIL_KEY]: 0,
+    [LLM_SESSION_UPDATED_AT_KEY]: 0,
+  };
+
+  if (clearAllChats) {
+    updates[LLM_CHAT_STATES_KEY] = {};
+  } else {
+    const siteKey = canonicalizeSiteKey(blockedHostname);
+    const data = await chrome.storage.local.get([LLM_CHAT_STATES_KEY]);
+    const states = data[LLM_CHAT_STATES_KEY] && typeof data[LLM_CHAT_STATES_KEY] === 'object'
+      ? data[LLM_CHAT_STATES_KEY]
+      : {};
+    if (states && typeof states === 'object') {
+      delete states[siteKey];
+      updates[LLM_CHAT_STATES_KEY] = states;
+    }
+  }
+
+  await chrome.storage.local.set(updates);
+}
+
+async function saveChatState() {
+  const now = Date.now();
+  const siteKey = canonicalizeSiteKey(blockedHostname);
+  const data = await chrome.storage.local.get([LLM_CHAT_STATES_KEY]);
+  const states =
+    data[LLM_CHAT_STATES_KEY] && typeof data[LLM_CHAT_STATES_KEY] === 'object'
+      ? data[LLM_CHAT_STATES_KEY]
+      : {};
+
+  states[siteKey] = {
+    updatedAt: now,
+    turns: conversationHistory.slice(),
+  };
+
+  await chrome.storage.local.set({
+    [LLM_CHAT_STATES_KEY]: states,
+    [LLM_SESSION_UPDATED_AT_KEY]: now,
+  });
+}
+
+async function pruneExpiredChatStates() {
+  const data = await chrome.storage.local.get([LLM_CHAT_STATES_KEY]);
+  const states =
+    data[LLM_CHAT_STATES_KEY] && typeof data[LLM_CHAT_STATES_KEY] === 'object'
+      ? data[LLM_CHAT_STATES_KEY]
+      : {};
+
+  const now = Date.now();
+  let didChange = false;
+  for (const [key, value] of Object.entries(states)) {
+    const updatedAt = typeof value?.updatedAt === 'number' ? value.updatedAt : 0;
+    if (!updatedAt || now - updatedAt > LLM_CHAT_TTL_MS) {
+      delete states[key];
+      didChange = true;
+    }
+  }
+
+  if (didChange) {
+    await chrome.storage.local.set({ [LLM_CHAT_STATES_KEY]: states });
+  }
+}
+
+async function loadChatStateIfFresh() {
+  const siteKey = canonicalizeSiteKey(blockedHostname);
+  const data = await chrome.storage.local.get([LLM_CHAT_STATES_KEY]);
+  const states =
+    data[LLM_CHAT_STATES_KEY] && typeof data[LLM_CHAT_STATES_KEY] === 'object'
+      ? data[LLM_CHAT_STATES_KEY]
+      : {};
+
+  const state = states?.[siteKey];
+  if (!state || typeof state !== 'object') {
+    return null;
+  }
+
+  const updatedAt = typeof state.updatedAt === 'number' ? state.updatedAt : 0;
+  const turns = Array.isArray(state.turns) ? state.turns : null;
+  if (!updatedAt || !turns) {
+    return null;
+  }
+
+  if (Date.now() - updatedAt > LLM_CHAT_TTL_MS) {
+    // Expired for this site: clear this site's chat and reset attempts.
+    await clearLlmSessionState({ clearAllChats: false });
+    return null;
+  }
+
+  return { updatedAt, turns };
+}
+
+async function expireSessionIfNeeded() {
+  const data = await chrome.storage.local.get([LLM_SESSION_UPDATED_AT_KEY]);
+  const updatedAt = typeof data[LLM_SESSION_UPDATED_AT_KEY] === 'number' ? data[LLM_SESSION_UPDATED_AT_KEY] : 0;
+  if (!updatedAt) {
+    return false;
+  }
+
+  if (Date.now() - updatedAt > LLM_CHAT_TTL_MS) {
+    await clearLlmSessionState({ clearAllChats: true });
+    return true;
+  }
+
+  return false;
+}
+
+function resetUiToFreshSession() {
+  messagesEl.innerHTML = '';
+  conversationHistory.length = 0;
+  const initialAiMessage = `You're trying to visit ${blockedHostname}, which is on your blocked list. What's your reason for needing access right now?`;
+  appendMessage('ai', initialAiMessage);
+  conversationHistory.push({ role: 'assistant', content: initialAiMessage });
+  void saveChatState();
+}
+
 function formatCooldown(msRemaining) {
   const totalSeconds = Math.max(0, Math.ceil(msRemaining / 1000));
   const minutes = Math.floor(totalSeconds / 60);
@@ -58,6 +186,12 @@ async function setLlmLimitState(next) {
 }
 
 async function enforceLlmCooldownUi() {
+  // If the overall session TTL elapsed, clear and reset attempts even if user didn't use all attempts.
+  const didExpire = await expireSessionIfNeeded();
+  if (didExpire) {
+    resetUiToFreshSession();
+  }
+
   const { count, cooldownUntil } = await getLlmLimitState();
   const now = Date.now();
   const remaining = cooldownUntil > now ? cooldownUntil - now : 0;
@@ -291,7 +425,14 @@ async function callLLM(history) {
     throw new Error('Not signed in. Sign in via the extension popup first.');
   }
 
-  const system = `${await loadSystemPrompt()}${SITE_CONTEXT_PROMPT}`;
+  // Tell the model which attempt this is (1..3) and whether it's the final attempt.
+  // Count tracks successful responses so far; the next request is count+1.
+  const state = await getLlmLimitState();
+  const attemptNumber = Math.min(LLM_MAX_REQUESTS, Math.max(1, (state.count ?? 0) + 1));
+  const isFinalAttempt = attemptNumber >= LLM_MAX_REQUESTS;
+  const attemptContext = `\n\nAttempt context:\n- attempt: ${attemptNumber}/${LLM_MAX_REQUESTS}\n- final_attempt: ${isFinalAttempt ? 'yes' : 'no'}\n`;
+
+  const system = `${await loadSystemPrompt()}${SITE_CONTEXT_PROMPT}${attemptContext}`;
 
   const res = await fetch(`${BACKEND_URL}/api/chat`, {
     method: 'POST',
@@ -348,6 +489,7 @@ async function sendMessage() {
 
   appendMessage('user', text);
   conversationHistory.push({ role: 'user', content: text });
+  await saveChatState();
 
   showTyping();
 
@@ -381,6 +523,7 @@ async function sendMessage() {
 
   conversationHistory.push({ role: 'assistant', content: cleanReply });
   appendMessage('ai', cleanReply, allowAccess);
+  await saveChatState();
 
   sendBtn.disabled = false;
   inputEl.focus();
@@ -403,11 +546,37 @@ inputEl.addEventListener('input', () => {
   inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
 });
 
-// Seed the conversation with the initial prompt shown to the user.
-const initialAiMessage = `You're trying to visit ${blockedHostname}, which is on your blocked list. What's your reason for needing access right now?`;
-appendMessage('ai', initialAiMessage);
-conversationHistory.push({ role: 'assistant', content: initialAiMessage });
+// Restore chat if it's still within the TTL; otherwise start fresh.
+void (async () => {
+  await pruneExpiredChatStates();
+  if (await expireSessionIfNeeded()) {
+    resetUiToFreshSession();
+    return;
+  }
+
+  const restored = await loadChatStateIfFresh();
+  if (restored?.turns?.length) {
+    // Replay prior turns into the UI + in-memory history.
+    for (const turn of restored.turns) {
+      const role = turn?.role === 'assistant' ? 'ai' : 'user';
+      const content = typeof turn?.content === 'string' ? turn.content : '';
+      if (!content) continue;
+      conversationHistory.push({ role: turn.role, content });
+      // Only show the allow button when the text contains approval token (historical)
+      const allowThrough = role === 'ai' && content.includes('ALLOW_ACCESS');
+      appendMessage(role, content.replace('ALLOW_ACCESS', '').trim(), allowThrough);
+    }
+    return;
+  }
+
+  resetUiToFreshSession();
+})();
 
 void enforceLlmCooldownUi();
 void hydrateOrgPolicyLine();
 inputEl.focus();
+
+// Keep expiring/resetting even if the tab stays open.
+setInterval(() => {
+  void enforceLlmCooldownUi();
+}, LLM_EXPIRY_POLL_MS);

--- a/extension/blocked-page.js
+++ b/extension/blocked-page.js
@@ -31,6 +31,9 @@ const ORG_IS_ADMIN_KEY = 'organizationIsAdmin';
 const ALLOW_DURATION_MINUTES_KEY = 'allowDurationMinutes';
 const ORG_ALLOW_DURATION_MINUTES_KEY = 'organizationAllowDurationMinutes';
 
+/** Dropdown options for personal (non-org) temporary allow; used for UI and chat parsing. */
+const PERSONAL_DURATION_OPTIONS = [5, 10, 15, 30, 60];
+
 const LLM_MAX_REQUESTS = 3;
 const LLM_COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
 const LLM_REQUEST_COUNT_KEY = 'llmRequestCount';
@@ -155,11 +158,11 @@ async function expireSessionIfNeeded() {
   return false;
 }
 
-function resetUiToFreshSession() {
+async function resetUiToFreshSession() {
   messagesEl.innerHTML = '';
   conversationHistory.length = 0;
   const initialAiMessage = `You're trying to visit ${blockedHostname}, which is on your blocked list. What's your reason for needing access right now?`;
-  appendMessage('ai', initialAiMessage);
+  await appendMessage('ai', initialAiMessage);
   conversationHistory.push({ role: 'assistant', content: initialAiMessage });
   void saveChatState();
 }
@@ -189,7 +192,7 @@ async function enforceLlmCooldownUi() {
   // If the overall session TTL elapsed, clear and reset attempts even if user didn't use all attempts.
   const didExpire = await expireSessionIfNeeded();
   if (didExpire) {
-    resetUiToFreshSession();
+    void resetUiToFreshSession();
   }
 
   const { count, cooldownUntil } = await getLlmLimitState();
@@ -247,7 +250,7 @@ function scrollToBottom() {
 }
 
 // Render one chat bubble and optionally attach the temporary allow button.
-function appendMessage(role, text, allowThrough = false) {
+async function appendMessage(role, text, allowThrough = false) {
   const wrap = document.createElement('div');
   wrap.className = `msg ${role}`;
 
@@ -269,7 +272,7 @@ function appendMessage(role, text, allowThrough = false) {
     btn.textContent = `Visit ${blockedHostname}`;
 
     // Only org admins and users without an org can choose a custom duration.
-    void hydrateAllowControls(row, btn);
+    await hydrateAllowControls(row, btn);
 
     btn.addEventListener('click', () => void grantAccessAndNavigate(btn));
     row.appendChild(btn);
@@ -351,6 +354,49 @@ async function getSavedAllowDurationMinutes() {
   return typeof value === 'number' && Number.isFinite(value) ? value : 5;
 }
 
+/** Last explicit duration mention in `text` that matches a dropdown option (5/10/15/30/60). */
+function parsePersonalDurationMinutes(text) {
+  if (!text) return null;
+  const s = String(text);
+  const explicit = [...s.matchAll(/\b(\d+)\s*(?:minute|minutes|min|mins)\b/gi)]
+    .map((m) => Number(m[1]))
+    .filter((n) => PERSONAL_DURATION_OPTIONS.includes(n));
+  if (explicit.length) return explicit[explicit.length - 1];
+  const short = [...s.matchAll(/\b(?:for|in|about|around)\s+(\d+)\b/gi)]
+    .map((m) => Number(m[1]))
+    .filter((n) => PERSONAL_DURATION_OPTIONS.includes(n));
+  if (short.length) return short[short.length - 1];
+  return null;
+}
+
+async function isPersonalPolicyUser() {
+  const data = await chrome.storage.local.get([ORG_ID_KEY]);
+  const orgId = typeof data[ORG_ID_KEY] === 'string' ? data[ORG_ID_KEY] : '';
+  return !orgId;
+}
+
+/** Persist preference and sync every personal allow-row dropdown + button label. */
+async function applyPersonalDurationFromChat(text) {
+  if (!(await isPersonalPolicyUser())) return;
+  const minutes = parsePersonalDurationMinutes(text);
+  if (minutes == null) return;
+  await chrome.storage.local.set({ [ALLOW_DURATION_MINUTES_KEY]: minutes });
+  syncPersonalDurationDropdowns(minutes);
+}
+
+function syncPersonalDurationDropdowns(minutes) {
+  if (!PERSONAL_DURATION_OPTIONS.includes(minutes)) return;
+  document.querySelectorAll('.allow-row').forEach((row) => {
+    const select = row.querySelector('.duration-select');
+    const btn = row.querySelector('.allow-btn');
+    if (!select || !btn) return;
+    if (![...select.options].some((o) => o.value === String(minutes))) return;
+    select.value = String(minutes);
+    btn.dataset.durationMinutes = String(minutes);
+    btn.textContent = `Visit ${blockedHostname} (${minutes} min)`;
+  });
+}
+
 async function hydrateAllowControls(row, btn) {
   // If the user is in an org, always use the org-wide duration (no selector).
   const orgData = await chrome.storage.local.get([ORG_ID_KEY]);
@@ -369,7 +415,7 @@ async function hydrateAllowControls(row, btn) {
 
   const select = document.createElement('select');
   select.className = 'duration-select';
-  const options = [5, 10, 15, 30, 60];
+  const options = PERSONAL_DURATION_OPTIONS;
   for (const minutes of options) {
     const opt = document.createElement('option');
     opt.value = String(minutes);
@@ -425,6 +471,13 @@ async function callLLM(history) {
     throw new Error('Not signed in. Sign in via the extension popup first.');
   }
 
+  const orgData = await chrome.storage.local.get([ORG_ID_KEY]);
+  const orgId = typeof orgData[ORG_ID_KEY] === 'string' ? orgData[ORG_ID_KEY] : '';
+  const isOrgUser = Boolean(orgId);
+
+  const personalDurationOptions = PERSONAL_DURATION_OPTIONS;
+  const orgAllowDurationMinutes = isOrgUser ? await getOrgAllowDurationMinutes() : null;
+
   // Tell the model which attempt this is (1..3) and whether it's the final attempt.
   // Count tracks successful responses so far; the next request is count+1.
   const state = await getLlmLimitState();
@@ -432,7 +485,11 @@ async function callLLM(history) {
   const isFinalAttempt = attemptNumber >= LLM_MAX_REQUESTS;
   const attemptContext = `\n\nAttempt context:\n- attempt: ${attemptNumber}/${LLM_MAX_REQUESTS}\n- final_attempt: ${isFinalAttempt ? 'yes' : 'no'}\n`;
 
-  const system = `${await loadSystemPrompt()}${SITE_CONTEXT_PROMPT}${attemptContext}`;
+  const accessTimeContext = isOrgUser
+    ? `\n\nTemporary access time policy:\n- policy: organization\n- allow_duration_minutes: ${orgAllowDurationMinutes}\n- instruction: Do NOT ask the user how long they need; the duration is fixed by the organization.\n`
+    : `\n\nTemporary access time policy:\n- policy: personal\n- allowed_options_minutes: ${personalDurationOptions.join(', ')}\n- instruction: If you need a time-box, ask the user to pick ONE of the allowed options.\n`;
+
+  const system = `${await loadSystemPrompt()}${SITE_CONTEXT_PROMPT}${accessTimeContext}${attemptContext}`;
 
   const res = await fetch(`${BACKEND_URL}/api/chat`, {
     method: 'POST',
@@ -456,7 +513,7 @@ async function sendMessage() {
   if (await enforceLlmCooldownUi()) {
     const { cooldownUntil } = await getLlmLimitState();
     const remaining = Math.max(0, cooldownUntil - Date.now());
-    appendMessage(
+    void appendMessage(
       'ai',
       `You’ve hit the limit of ${LLM_MAX_REQUESTS} requests. Please wait ${formatCooldown(
         remaining
@@ -473,7 +530,7 @@ async function sendMessage() {
   const stateBeforeCall = await getLlmLimitState();
   if (stateBeforeCall.count >= LLM_MAX_REQUESTS) {
     const remaining = Math.max(0, stateBeforeCall.cooldownUntil - Date.now());
-    appendMessage(
+    void appendMessage(
       'ai',
       `You’ve hit the limit of ${LLM_MAX_REQUESTS} requests. Please wait ${formatCooldown(
         remaining
@@ -487,7 +544,8 @@ async function sendMessage() {
   inputEl.style.height = 'auto';
   sendBtn.disabled = true;
 
-  appendMessage('user', text);
+  await appendMessage('user', text);
+  await applyPersonalDurationFromChat(text);
   conversationHistory.push({ role: 'user', content: text });
   await saveChatState();
 
@@ -498,7 +556,7 @@ async function sendMessage() {
     reply = await callLLM(conversationHistory);
   } catch {
     removeTyping();
-    appendMessage('ai', 'Something went wrong reaching the AI. Try again.');
+    void appendMessage('ai', 'Something went wrong reaching the AI. Try again.');
     sendBtn.disabled = false;
     // Do not consume an attempt if the AI request failed.
     await enforceLlmCooldownUi();
@@ -522,7 +580,8 @@ async function sendMessage() {
   const cleanReply = reply.replace('ALLOW_ACCESS', '').trim();
 
   conversationHistory.push({ role: 'assistant', content: cleanReply });
-  appendMessage('ai', cleanReply, allowAccess);
+  await appendMessage('ai', cleanReply, allowAccess);
+  await applyPersonalDurationFromChat(cleanReply);
   await saveChatState();
 
   sendBtn.disabled = false;
@@ -550,7 +609,7 @@ inputEl.addEventListener('input', () => {
 void (async () => {
   await pruneExpiredChatStates();
   if (await expireSessionIfNeeded()) {
-    resetUiToFreshSession();
+    await resetUiToFreshSession();
     return;
   }
 
@@ -564,12 +623,14 @@ void (async () => {
       conversationHistory.push({ role: turn.role, content });
       // Only show the allow button when the text contains approval token (historical)
       const allowThrough = role === 'ai' && content.includes('ALLOW_ACCESS');
-      appendMessage(role, content.replace('ALLOW_ACCESS', '').trim(), allowThrough);
+      const display = content.replace('ALLOW_ACCESS', '').trim();
+      await appendMessage(role, display, allowThrough);
+      await applyPersonalDurationFromChat(display);
     }
     return;
   }
 
-  resetUiToFreshSession();
+  await resetUiToFreshSession();
 })();
 
 void enforceLlmCooldownUi();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,6 +12,7 @@
   "permissions": [
     "identity",
     "identity.email",
+    "alarms",
     "storage",
     "tabs",
     "webNavigation"

--- a/extension/system-prompt.md
+++ b/extension/system-prompt.md
@@ -38,6 +38,16 @@ ALLOW_ACCESS
 
 - If you decide to deny, do **not** include that token.
 
+## Final-attempt behavior (IMPORTANT)
+The user only gets a few chances to convince you.
+
+- If the attached context indicates `final_attempt: yes`, you must give a **final decision** and acknowledge it is the last attempt.
+- In that case, include one of these lines somewhere in your response:
+  - `Decision: ACCESS GRANTED`
+  - `Decision: ACCESS DENIED`
+  
+If access is granted, still include `ALLOW_ACCESS` as specified above.
+
 ## Response templates
 ### Approve (example)
 State the allowed purpose and time box, then output the token.

--- a/extension/system-prompt.md
+++ b/extension/system-prompt.md
@@ -10,6 +10,12 @@ The user is requesting temporary access to a blocked website. Your job is to dec
 ## Decision rule (what “legitimate” means)
 Approve access only when the reason is **task-critical and time-bounded**.
 
+## Temporary access time (IMPORTANT)
+You will receive an attached “Temporary access time policy” section.
+
+- If `policy: organization`, the allow duration is **fixed**. Do **not** ask the user how long they need.
+- If `policy: personal`, the user must choose a time-box from the provided `allowed_options_minutes` list. If you need a time-box, ask them to pick **one** of those options.
+
 ### Strong reasons (usually approve)
 - The visit is **required** to complete a current work/school task (e.g., documentation, vendor portal, ticket, account login, critical message).
 - The user has a **specific objective** and it can be completed quickly.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
   getExtensionId,
   getOAuthClientId,
   getProfileEmail,
+  loadSavedUserId,
   loadSavedToken,
   removeCachedToken,
   saveOrganizationContext,
@@ -112,8 +113,9 @@ function App() {
 
     async function initialize() {
       try {
-        const [savedToken, personalWebsites, orgWebsites] = await Promise.all([
+        const [savedToken, savedUserId, personalWebsites, orgWebsites] = await Promise.all([
           loadSavedToken(),
+          loadSavedUserId(),
           loadPersonalBlockedWebsites(),
           loadOrgBlockedWebsites(),
         ]);
@@ -132,9 +134,10 @@ function App() {
 
         setPersonalBlockedWebsites(personalWebsites);
         setOrgBlockedWebsites(orgWebsites);
+        const resolvedUserId = nextEmail || savedUserId || '';
         setEmail(nextEmail);
-        if (nextEmail) {
-          void saveUserId(nextEmail);
+        if (resolvedUserId) {
+          void saveUserId(resolvedUserId);
         }
 
         if (savedToken) {
@@ -143,8 +146,8 @@ function App() {
             console.error('upsertOAuthUser failed during initialization:', error);
           });
 
-          if (nextEmail) {
-            void refreshOrganizationForUser(nextEmail, savedToken).catch((error) => {
+          if (resolvedUserId) {
+            void refreshOrganizationForUser(resolvedUserId, savedToken).catch((error) => {
               console.error('initialize org refresh failed:', error);
             });
           } else {

--- a/frontend/src/features/auth/auth.ts
+++ b/frontend/src/features/auth/auth.ts
@@ -61,6 +61,16 @@ export async function saveUserId(userId: string) {
   }
 }
 
+export async function loadSavedUserId() {
+  if (!chromeApi?.storage?.local) {
+    return null;
+  }
+
+  const data = await chromeApi.storage.local.get(USER_ID_KEY);
+  const value = data[USER_ID_KEY];
+  return typeof value === 'string' && value.trim() ? value.trim().toLowerCase() : null;
+}
+
 // Load the previously saved OAuth token if one exists.
 export async function loadSavedToken() {
   if (!chromeApi?.storage?.local) {


### PR DESCRIPTION
Fixed several issues:
LLM chat was cleared upon refresh/closing browser; now persists for 10 minutes (after which chat clears and attempts reset)
LLM didn't acknowledge how many attempts user had left; now gives "access denied" message after final attempt if user is unable to provide justification
Popup wouldn't read that user was in an org unless user signed out and back in; now works correctly
After temporary access was granted, the user was not blocked from the site unless the page was reloaded; now makes use of a chrome alarm to actively block user after access time has passed
Navigating to subdomains of a site would reactive the block; subdomains are now also permitted
Added context for LLM to know what the allowed access times were
Further fixing of site blocking to reactivate after time is up

Swapped AI model to Gemini